### PR TITLE
Task/simple security csrf jwt

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,11 +29,18 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.0.0.RELEASE'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-undertow', version: '2.0.0.RELEASE'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '2.0.0.RELEASE'
+    compile group: 'org.springframework.security.oauth', name: 'spring-security-oauth2', version: '2.3.0.RELEASE'
+    compile group: 'org.springframework.security.oauth.boot', name: 'spring-security-oauth2-autoconfigure', version: '2.0.0.RELEASE'
     compile group: 'io.springfox', name: 'springfox-swagger2', version: '2.8.0'
     compile group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.8.0'
+    compile group: 'com.auth0', name: 'java-jwt', version: '3.3.0'
+    compile group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.0'
 
 
     compile group: 'org.projectlombok', name: 'lombok', version:'1.16.20'
     testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile 'io.rest-assured:rest-assured:3.1.0'
+    testCompile 'io.rest-assured:json-schema-validator:3.1.0'
+    testCompile group: 'org.testng', name: 'testng', version: '6.14.3'
 }
 

--- a/backend/src/main/java/com/advisor/configuration/ClientResources.java
+++ b/backend/src/main/java/com/advisor/configuration/ClientResources.java
@@ -1,0 +1,22 @@
+package com.advisor.configuration;
+
+import org.springframework.boot.autoconfigure.security.oauth2.resource.ResourceServerProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.security.oauth2.client.token.grant.code.AuthorizationCodeResourceDetails;
+
+class ClientResources {
+
+    @NestedConfigurationProperty
+    private AuthorizationCodeResourceDetails client = new AuthorizationCodeResourceDetails();
+
+    @NestedConfigurationProperty
+    private ResourceServerProperties resource = new ResourceServerProperties();
+
+    public AuthorizationCodeResourceDetails getClient() {
+        return client;
+    }
+
+    public ResourceServerProperties getResource() {
+        return resource;
+    }
+}

--- a/backend/src/main/java/com/advisor/configuration/SecurityConfiguration.java
+++ b/backend/src/main/java/com/advisor/configuration/SecurityConfiguration.java
@@ -111,6 +111,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers("/").permitAll()
                 .antMatchers("/afterLogin").permitAll()
                 .antMatchers("/hello").permitAll()
+                .antMatchers("/login/google").permitAll()
+                .antMatchers("/login/facebook").permitAll()
                 .antMatchers("/getUserProfile/**").hasAuthority("USER")
                 .antMatchers("/updateUserProfile").hasAuthority("USER")
                 .antMatchers("/advertisement/**").hasAuthority("USER")
@@ -142,7 +144,12 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     private Filter filterChain() throws Exception {
         List<Filter> filters = new ArrayList<Filter>();
         filters.add(new PreLoginFilter("/login/**", jwtManager, frontendUrl + dashboardUrl));
-        filters.add(new JWTAuthorizationFilter(jwtManager,"/**"));
+        filters.add(new JWTAuthorizationFilter(jwtManager, new NegatedRequestMatcher(
+                new OrRequestMatcher(
+                        new AntPathRequestMatcher("/login/facebook"),
+                        new AntPathRequestMatcher("/login/google")
+                )
+        )));
         filters.add(ssoFilter(facebook(), "/login/facebook"));
         filters.add(ssoFilter(google(), "/login/google"));
 

--- a/backend/src/main/java/com/advisor/configuration/SecurityConfiguration.java
+++ b/backend/src/main/java/com/advisor/configuration/SecurityConfiguration.java
@@ -1,12 +1,17 @@
 package com.advisor.configuration;
 
+import javax.servlet.Filter;
 import javax.sql.DataSource;
 
+import com.advisor.security.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 
 
+import org.springframework.boot.autoconfigure.security.oauth2.resource.UserInfoTokenServices;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -14,16 +19,31 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.oauth2.client.OAuth2ClientContext;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.security.oauth2.client.filter.OAuth2ClientAuthenticationProcessingFilter;
+import org.springframework.security.oauth2.client.filter.OAuth2ClientContextFilter;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableOAuth2Client;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CompositeFilter;
+import org.springframework.web.filter.CorsFilter;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
+@EnableOAuth2Client
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Autowired
@@ -38,6 +58,27 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Value("${spring.queries.roles-query}")
     private String rolesQuery;
+
+    @Autowired
+    private OAuth2ClientContext oauth2ClientContext;
+
+    @Autowired
+    private OAuth2ClientContextFilter oauth2ClientContextFilter;
+
+    @Autowired
+    private LoginAuthenticationHandler handler;
+
+    @Autowired
+    private Oauth2LoginAuthenticationHandler oauth2Handler;
+
+    @Autowired
+    private JWTManager jwtManager;
+
+    @Value("${frontend.url.parent}")
+    String frontendUrl;
+
+    @Value("${frontend.url.main}")
+    String dashboardUrl;
 
     @Override
     protected void configure(AuthenticationManagerBuilder auth)
@@ -54,11 +95,21 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
 
         http.
-                authorizeRequests()
-
+                sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .addFilterBefore(filterChain(), UsernamePasswordAuthenticationFilter.class)
+                .logout().disable()
+                .csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()).requireCsrfProtectionMatcher(
+                        new NegatedRequestMatcher(
+                                new OrRequestMatcher(
+                                        new AntPathRequestMatcher("/login/facebook"),
+                                        new AntPathRequestMatcher("/login/google")
+                                )
+                        ))
+                .and()
+                .authorizeRequests()
                 .antMatchers("/").permitAll()
                 .antMatchers("/afterLogin").permitAll()
-                .antMatchers("/populate").permitAll()
                 .antMatchers("/hello").permitAll()
                 .antMatchers("/getUserProfile/**").hasAuthority("USER")
                 .antMatchers("/updateUserProfile").hasAuthority("USER")
@@ -74,17 +125,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers("/login").permitAll()
                 .antMatchers("/registration").permitAll()
                 .antMatchers("/registrationConfirm").permitAll()
-                .antMatchers("/admin/**").hasAuthority("ADMIN").anyRequest()
-                .authenticated().and().csrf().disable().formLogin()
-                .loginPage("/login").permitAll()
-                .failureUrl("/login?error=true")
-                .defaultSuccessUrl("/afterLogin")
-                .usernameParameter("email")
-                .passwordParameter("password")
-                .and().logout()
-                .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
-                .logoutSuccessUrl("/").and().exceptionHandling()
-                .accessDeniedPage("/access-denied")
+                .antMatchers("/admin/**").hasAuthority("ADMIN")
+                .anyRequest()
+                .authenticated()
                 .and()
                 .cors();
     }
@@ -93,18 +136,71 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     public void configure(WebSecurity web) {
         web
                 .ignoring()
-                .antMatchers("/resources/**", "/static/**", "/css/**", "/js/**", "/images/**");
+                .antMatchers("/resources/**", "/static/**", "/css/**", "/js/**", "/images/**", "/csrf", "/populate");
+    }
+
+    private Filter filterChain() throws Exception {
+        List<Filter> filters = new ArrayList<Filter>();
+        filters.add(new PreLoginFilter("/login/**", jwtManager, frontendUrl + dashboardUrl));
+        filters.add(new JWTAuthorizationFilter(jwtManager,"/**"));
+        filters.add(ssoFilter(facebook(), "/login/facebook"));
+        filters.add(ssoFilter(google(), "/login/google"));
+
+        JWTAuthenticationFilter loginFilter = new JWTAuthenticationFilter(this.authenticationManager(),jwtManager);
+        loginFilter.setAuthenticationSuccessHandler(handler);
+        loginFilter.setAuthenticationFailureHandler(handler);
+        loginFilter.setFilterProcessesUrl("/login");
+        filters.add(loginFilter);
+
+        CompositeFilter compositeFilter = new CompositeFilter();
+        compositeFilter.setFilters(filters);
+        return compositeFilter;
+    }
+
+    private Filter ssoFilter(ClientResources client, String path) {
+        OAuth2ClientAuthenticationProcessingFilter oAuth2ClientAuthenticationFilter = new OAuth2ClientAuthenticationProcessingFilter(path);
+        OAuth2RestTemplate oAuth2RestTemplate = new OAuth2RestTemplate(client.getClient(), oauth2ClientContext);
+        oAuth2ClientAuthenticationFilter.setRestTemplate(oAuth2RestTemplate);
+        UserInfoTokenServices tokenServices = new UserInfoTokenServices(client.getResource().getUserInfoUri(),
+                client.getClient().getClientId());
+        tokenServices.setRestTemplate(oAuth2RestTemplate);
+        oAuth2ClientAuthenticationFilter.setTokenServices(tokenServices);
+        oAuth2ClientAuthenticationFilter.setAuthenticationSuccessHandler(oauth2Handler);
+        return oAuth2ClientAuthenticationFilter;
     }
 
     @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        final CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedHeaders(Collections.singletonList("*"));
-        configuration.setAllowedOrigins(Collections.singletonList("*"));
-        configuration.setAllowedMethods(Collections.singletonList("*"));
-        final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
+    public FilterRegistrationBean oauth2ClientFilterRegistration(
+            OAuth2ClientContextFilter filter) {
+        FilterRegistrationBean registration = new FilterRegistrationBean();
+        registration.setFilter(filter);
+        registration.setOrder(-103);
+        return registration;
+    }
 
-        return source;
+    @Bean
+    public FilterRegistrationBean corsConfigFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOrigin(frontendUrl);
+        config.addAllowedMethod("*");
+        config.addAllowedHeader("*");
+        source.registerCorsConfiguration("/**", config);
+        FilterRegistrationBean bean = new FilterRegistrationBean(new CorsFilter(source));
+        bean.setOrder(-100);
+        return bean;
+    }
+
+    @Bean
+    @ConfigurationProperties("google")
+    public ClientResources google() {
+        return new ClientResources();
+    }
+
+    @Bean
+    @ConfigurationProperties("facebook")
+    public ClientResources facebook() {
+        return new ClientResources();
     }
 }

--- a/backend/src/main/java/com/advisor/controllers/CsrfController.java
+++ b/backend/src/main/java/com/advisor/controllers/CsrfController.java
@@ -1,0 +1,28 @@
+package com.advisor.controllers;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.http.Cookie;
+
+@Controller
+public class CsrfController {
+
+    CookieCsrfTokenRepository csrfRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+
+    @RequestMapping(value = "/csrf", method = RequestMethod.GET)
+    public ResponseEntity setCsrf() {
+        ServletRequestAttributes attributes =
+                ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes());
+        CsrfToken token = csrfRepository.generateToken(attributes.getRequest());
+        csrfRepository.saveToken(token,attributes.getRequest(),attributes.getResponse());
+        return ResponseEntity.ok("");
+    }
+}

--- a/backend/src/main/java/com/advisor/controllers/LogoutController.java
+++ b/backend/src/main/java/com/advisor/controllers/LogoutController.java
@@ -1,0 +1,27 @@
+package com.advisor.controllers;
+
+import com.advisor.security.JWTManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@RestController
+public class LogoutController {
+
+    @Autowired
+    private JWTManager jwtManager;
+
+    @RequestMapping(value = "/logout", method = RequestMethod.POST)
+    public ResponseEntity logout() {
+        ServletRequestAttributes attributes =
+                ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes());
+        jwtManager.jwtLogout(attributes.getRequest(),attributes.getResponse());
+        return new ResponseEntity(HttpStatus.OK);
+    }
+}

--- a/backend/src/main/java/com/advisor/controllers/PopulateController.java
+++ b/backend/src/main/java/com/advisor/controllers/PopulateController.java
@@ -8,6 +8,7 @@ import com.advisor.model.request.NewUserRequest;
 import com.advisor.repository.CoachTypeRepository;
 import com.advisor.repository.RecurringTypeRepository;
 import com.advisor.repository.RoleRepository;
+import com.advisor.repository.UserRepository;
 import com.advisor.service.AdvertisementService;
 import com.advisor.service.Exceptions.DataRepositoryException;
 import com.advisor.service.Exceptions.EntityNotFoundException;
@@ -50,8 +51,11 @@ public class PopulateController {
     @Qualifier("coachTypeRepository")
     private CoachTypeRepository coachTypeRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
     @RequestMapping(value = { "/populate" }, method = RequestMethod.GET)
-    public ResponseEntity populate()
+    public ResponseEntity populate() throws Exception
     {
         //save roles
         List<Role> roles = new ArrayList<>();
@@ -86,6 +90,8 @@ public class PopulateController {
         NewUserRequest newUserRequest = new NewUserRequest(email, "Marek", "Makowski", "Katowice", "111111", "client");
         userService.registerClient(newUserRequest);
         User user = userService.findUserByEmail(email);
+        user.setActive(true);
+        user = userRepository.save(user);
 
         //adv1
         AdvertisementRequest advertisementRequest = new AdvertisementRequest("Genialne moje ogloszenie", "bodybuilding");
@@ -98,6 +104,8 @@ public class PopulateController {
 
         //User2
         User user2 = userService.findUserByEmail(email);
+        user2.setActive(true);
+        user2 = userRepository.save(user2);
 
         //Meeting1
         try {

--- a/backend/src/main/java/com/advisor/model/entity/TokenJWT.java
+++ b/backend/src/main/java/com/advisor/model/entity/TokenJWT.java
@@ -4,6 +4,7 @@ import lombok.Data;
 
 import javax.persistence.*;
 import java.util.Date;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -21,4 +22,18 @@ public class TokenJWT {
 
     @Column(nullable = false)
     private Date timestamp;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TokenJWT tokenJWT = (TokenJWT) o;
+        return Objects.equals(user, tokenJWT.user) &&
+                Objects.equals(timestamp, tokenJWT.timestamp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tokenId);
+    }
 }

--- a/backend/src/main/java/com/advisor/model/entity/TokenJWT.java
+++ b/backend/src/main/java/com/advisor/model/entity/TokenJWT.java
@@ -1,0 +1,24 @@
+package com.advisor.model.entity;
+
+import lombok.Data;
+
+import javax.persistence.*;
+import java.util.Date;
+import java.util.UUID;
+
+@Entity
+@Data
+public class TokenJWT {
+
+    @Id
+    @org.hibernate.annotations.Type(type = "pg-uuid")
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "tokenId",unique=true, nullable = false)
+    private UUID tokenId;
+
+    @ManyToOne(cascade = CascadeType.MERGE)
+    private User user;
+
+    @Column(nullable = false)
+    private Date timestamp;
+}

--- a/backend/src/main/java/com/advisor/model/request/LoginRequest.java
+++ b/backend/src/main/java/com/advisor/model/request/LoginRequest.java
@@ -1,0 +1,10 @@
+package com.advisor.model.request;
+
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+    private String username;
+
+    private String password;
+}

--- a/backend/src/main/java/com/advisor/repository/TokenJWTRepository.java
+++ b/backend/src/main/java/com/advisor/repository/TokenJWTRepository.java
@@ -1,0 +1,9 @@
+package com.advisor.repository;
+
+import com.advisor.model.entity.TokenJWT;
+import org.springframework.stereotype.Repository;
+
+@Repository("blacklistRepository")
+public interface TokenJWTRepository extends SimplyRepository<TokenJWT>{
+
+}

--- a/backend/src/main/java/com/advisor/repository/UserRepository.java
+++ b/backend/src/main/java/com/advisor/repository/UserRepository.java
@@ -3,6 +3,7 @@ package com.advisor.repository;
 
 import com.advisor.model.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;

--- a/backend/src/main/java/com/advisor/security/JWTAuthenticationFilter.java
+++ b/backend/src/main/java/com/advisor/security/JWTAuthenticationFilter.java
@@ -1,0 +1,45 @@
+package com.advisor.security;
+
+import com.advisor.model.request.LoginRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+
+public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private AuthenticationManager authenticationManager;
+
+    private JWTManager jwtManager;
+
+    public JWTAuthenticationFilter(AuthenticationManager authenticationManager, JWTManager jwtManager) {
+        this.authenticationManager = authenticationManager;
+        this.jwtManager = jwtManager;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest req,
+                                                HttpServletResponse res) throws AuthenticationException {
+        try {
+            LoginRequest creds = new ObjectMapper()
+                    .readValue(req.getInputStream(), LoginRequest.class);
+
+            return authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            creds.getUsername(),
+                            creds.getPassword(),
+                            new ArrayList<>())
+            );
+        } catch (IOException e) {
+            throw new AuthenticationCredentialsNotFoundException("Invalid JSON request.");
+        }
+    }
+}

--- a/backend/src/main/java/com/advisor/security/JWTAuthorizationFilter.java
+++ b/backend/src/main/java/com/advisor/security/JWTAuthorizationFilter.java
@@ -1,0 +1,48 @@
+package com.advisor.security;
+
+import org.springframework.security.authentication.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+
+public class JWTAuthorizationFilter extends AbstractAuthenticationProcessingFilter {
+
+    private JWTManager jwtManager;
+
+    public JWTAuthorizationFilter(JWTManager jwtManager, String defaultFilterProcessesUrl) {
+        super(defaultFilterProcessesUrl);
+        this.jwtManager = jwtManager;
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request,
+                                            HttpServletResponse response, FilterChain chain, Authentication authResult)
+            throws IOException, ServletException {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Jwt authentication finished. Updating SecurityContextHolder to contain: "
+                    + authResult);
+        }
+
+        SecurityContextHolder.getContext().setAuthentication(authResult);
+        chain.doFilter(request,response);
+        return;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException, ServletException {
+        return Optional.ofNullable((AbstractAuthenticationToken)jwtManager.authenticateJwt(request, response))
+                .orElseGet(() -> new AnonymousAuthenticationToken("No valid jwt token found", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+    }
+}

--- a/backend/src/main/java/com/advisor/security/JWTAuthorizationFilter.java
+++ b/backend/src/main/java/com/advisor/security/JWTAuthorizationFilter.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -21,8 +22,9 @@ public class JWTAuthorizationFilter extends AbstractAuthenticationProcessingFilt
 
     private JWTManager jwtManager;
 
-    public JWTAuthorizationFilter(JWTManager jwtManager, String defaultFilterProcessesUrl) {
-        super(defaultFilterProcessesUrl);
+    public JWTAuthorizationFilter(JWTManager jwtManager, RequestMatcher matcher) {
+        super("/");
+        this.setRequiresAuthenticationRequestMatcher(matcher);
         this.jwtManager = jwtManager;
     }
 

--- a/backend/src/main/java/com/advisor/security/JWTManager.java
+++ b/backend/src/main/java/com/advisor/security/JWTManager.java
@@ -87,8 +87,8 @@ public class JWTManager {
         response.addCookie(createTokenCookie(user.getEmail(), authorities, tokenEntity.getTokenId().toString()));
     }
 
-    public UsernamePasswordAuthenticationToken authenticateJwt(HttpServletRequest req, HttpServletResponse res) {
-        Cookie[] cookies = req.getCookies();
+    public UsernamePasswordAuthenticationToken authenticateJwt(HttpServletRequest request, HttpServletResponse response) {
+        Cookie[] cookies = request.getCookies();
         if(cookies == null) {
             return null;
         }
@@ -107,7 +107,7 @@ public class JWTManager {
             String user = jws.getBody().getSubject();
             if (user != null
                     && tokenJWTRepository.existsById(UUID.fromString(jws.getBody().getId()))) {
-                        res.addCookie(jwtCookie.get());
+                        response.addCookie(jwtCookie.get());
                         List<GrantedAuthority> authorities = new ArrayList<>();
                         for(String role : roles) {
                             if((boolean)jws.getBody().get(role)) {

--- a/backend/src/main/java/com/advisor/security/JWTManager.java
+++ b/backend/src/main/java/com/advisor/security/JWTManager.java
@@ -1,0 +1,143 @@
+package com.advisor.security;
+
+import com.advisor.model.entity.Role;
+import com.advisor.model.entity.TokenJWT;
+import com.advisor.model.entity.User;
+import com.advisor.repository.TokenJWTRepository;
+import com.advisor.repository.UserRepository;
+import com.advisor.service.Exceptions.DataRepositoryException;
+import com.advisor.service.UserService;
+import io.jsonwebtoken.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+public class JWTManager {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private TokenJWTRepository tokenJWTRepository;
+
+    private static final String TOKEN_COOKIE_NAME = "_secu";
+    private static final String SECRET = "SecretKeyToGenJWTs";
+    private static final String [] roles = {"USER","ADMIN","COACH"};
+
+    public void jwtLogout(HttpServletRequest req, HttpServletResponse res) {
+        Cookie[] cookies = req.getCookies();
+        if(cookies == null) {
+            return;
+        }
+        Arrays.stream(cookies)
+                .filter(cookie -> cookie.getName().equals(TOKEN_COOKIE_NAME))
+                .findFirst()
+                .ifPresent(cookie -> {
+                    Optional.ofNullable(cookie.getValue()).ifPresent(value -> {
+                        Jws<Claims> jws = Jwts.parser()
+                                .setSigningKey(SECRET.getBytes())
+                                .parseClaimsJws(value);
+                        String userName = jws.getBody().getSubject();
+                        User user = userRepository.findByEmail(userName);
+                        Optional.ofNullable(user).ifPresent(lUser -> {
+                            if(tokenJWTRepository.existsById(UUID.fromString(jws.getBody().getId()))) {
+                                TokenJWT jwtToken = tokenJWTRepository.getOne(UUID.fromString(jws.getBody().getId()));
+                                tokenJWTRepository.delete(jwtToken);
+                            }
+                        });
+                    });
+                    cookie.setMaxAge(0);
+                    res.addCookie(cookie);
+                });
+        return;
+    }
+
+    public void jwtLogin(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        Object principal = authentication.getPrincipal();
+        User user = null;
+        List<String> authorities = new ArrayList<>();
+        if(principal instanceof org.springframework.security.core.userdetails.User) {
+            user = userService.findUserByEmail(((org.springframework.security.core.userdetails.User) principal).getUsername());
+            authorities = authentication.getAuthorities().stream().map(a -> ((GrantedAuthority) a).getAuthority()).collect(Collectors.toList());
+        } else {
+            final String email = (String) ((Map) ((OAuth2Authentication) authentication).getUserAuthentication().getDetails()).get("email");
+            user = Optional.ofNullable(userService.findUserByEmail(email)).orElseGet(() -> {
+                return userService.registerOauth2User(email);
+            });
+            authorities = user.getRoles().stream().map(r -> r.getRole()).collect(Collectors.toList());
+        }
+        TokenJWT tokenEntity = new TokenJWT();
+        tokenEntity.setTimestamp(new Date(System.currentTimeMillis()));
+        tokenEntity.setUser(user);
+        tokenEntity = tokenJWTRepository.save(tokenEntity);
+        response.addCookie(createTokenCookie(user.getEmail(), authorities, tokenEntity.getTokenId().toString()));
+    }
+
+    public UsernamePasswordAuthenticationToken authenticateJwt(HttpServletRequest req, HttpServletResponse res) {
+        Cookie[] cookies = req.getCookies();
+        if(cookies == null) {
+            return null;
+        }
+        Optional<Cookie> jwtCookie = Arrays.stream(cookies)
+                .filter(cookie -> cookie.getName().equals(TOKEN_COOKIE_NAME) && cookie.getValue()!=null)
+                .findFirst();
+        if(jwtCookie.isPresent()) {
+            Jws<Claims> jws = null;
+            try {
+                jws = Jwts.parser()
+                        .setSigningKey(SECRET.getBytes())
+                        .parseClaimsJws(jwtCookie.get().getValue());
+            } catch (JwtException | IllegalArgumentException e) {
+                return null;
+            }
+            String user = jws.getBody().getSubject();
+            if (user != null
+                    && tokenJWTRepository.existsById(UUID.fromString(jws.getBody().getId()))) {
+                        res.addCookie(jwtCookie.get());
+                        List<GrantedAuthority> authorities = new ArrayList<>();
+                        for(String role : roles) {
+                            if((boolean)jws.getBody().get(role)) {
+                                authorities.add(new SimpleGrantedAuthority(role));
+                            }
+                        }
+                        return new UsernamePasswordAuthenticationToken(user, null, authorities);
+            }
+        }
+        return null;
+    }
+
+    private Cookie createTokenCookie(String subject, List<String> authorities, String id) {
+        Cookie tokenCookie = new Cookie(TOKEN_COOKIE_NAME, createToken(subject, authorities, id));
+        tokenCookie.setHttpOnly(true);
+        tokenCookie.setPath("/");
+        return tokenCookie;
+    }
+
+    private String createToken(String subject, List<String> authorities, String id) {
+        Claims claims = Jwts.claims()
+                .setSubject(subject)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setId(id);
+        for(String role : roles) {
+            claims.put(role, authorities.contains(role));
+        }
+        return Jwts.builder()
+                .setClaims(claims)
+                .signWith(SignatureAlgorithm.HS512, SECRET.getBytes())
+                .compact();
+    }
+}

--- a/backend/src/main/java/com/advisor/security/LoginAuthenticationHandler.java
+++ b/backend/src/main/java/com/advisor/security/LoginAuthenticationHandler.java
@@ -1,0 +1,51 @@
+package com.advisor.security;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class LoginAuthenticationHandler implements AuthenticationSuccessHandler, AuthenticationFailureHandler {
+
+    @Autowired
+    JWTManager jwtManager;
+
+    @Value("${frontend.url.parent}")
+    String frontendUrl;
+
+    @Value("${frontend.url.main}")
+    String dashboardUrl;
+
+    @Value("${frontend.url.login}")
+    String loginUrl;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        jwtManager.jwtLogin(request,response,authentication);
+        response.setStatus(200);
+    }
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        response.sendError(401);
+    }
+}

--- a/backend/src/main/java/com/advisor/security/Oauth2LoginAuthenticationHandler.java
+++ b/backend/src/main/java/com/advisor/security/Oauth2LoginAuthenticationHandler.java
@@ -1,0 +1,41 @@
+package com.advisor.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class Oauth2LoginAuthenticationHandler implements AuthenticationSuccessHandler, AuthenticationFailureHandler {
+
+    @Autowired
+    JWTManager jwtManager;
+
+    @Value("${frontend.url.parent}")
+    String frontendUrl;
+
+    @Value("${frontend.url.main}")
+    String dashboardUrl;
+
+    @Value("${frontend.url.login}")
+    String loginUrl;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        jwtManager.jwtLogin(request,response,authentication);
+        response.sendRedirect(frontendUrl + "/#" + dashboardUrl);
+    }
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        response.sendRedirect(frontendUrl + "/#" + loginUrl);
+    }
+}

--- a/backend/src/main/java/com/advisor/security/PreLoginFilter.java
+++ b/backend/src/main/java/com/advisor/security/PreLoginFilter.java
@@ -1,0 +1,46 @@
+package com.advisor.security;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+
+public class PreLoginFilter extends AbstractAuthenticationProcessingFilter {
+
+    private JWTManager jwtManager;
+
+    private String alreadyLoggedRedirectUrl;
+
+    public PreLoginFilter(String defaultFilterProcessesUrl, JWTManager jwtManager, String alreadyLoggedRedirectUrl) {
+        super(defaultFilterProcessesUrl);
+        this.jwtManager = jwtManager;
+        this.alreadyLoggedRedirectUrl = alreadyLoggedRedirectUrl;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException, ServletException {
+        return Optional.ofNullable((AbstractAuthenticationToken)jwtManager.authenticateJwt(request, response))
+                .orElseGet(() -> new AnonymousAuthenticationToken("No valid jwt token found", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request,
+                                            HttpServletResponse response, FilterChain chain, Authentication authResult)
+            throws IOException, ServletException {
+        if (authResult instanceof AnonymousAuthenticationToken) {
+            chain.doFilter(request, response);
+            return;
+        }
+        response.sendRedirect(alreadyLoggedRedirectUrl);
+        return;
+    }
+}

--- a/backend/src/main/java/com/advisor/security/PreLoginFilter.java
+++ b/backend/src/main/java/com/advisor/security/PreLoginFilter.java
@@ -5,6 +5,7 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 
 import javax.servlet.FilterChain;
@@ -37,6 +38,7 @@ public class PreLoginFilter extends AbstractAuthenticationProcessingFilter {
                                             HttpServletResponse response, FilterChain chain, Authentication authResult)
             throws IOException, ServletException {
         if (authResult instanceof AnonymousAuthenticationToken) {
+            SecurityContextHolder.getContext().setAuthentication(null);
             chain.doFilter(request, response);
             return;
         }

--- a/backend/src/main/java/com/advisor/service/UserService.java
+++ b/backend/src/main/java/com/advisor/service/UserService.java
@@ -18,6 +18,8 @@ public interface UserService extends IService<User, UUID> {
 
 	void registerClient(NewUserRequest newUserRequest);
 
+	User registerOauth2User(String email);
+
 	Optional<User> findById(UUID userId);
 
 	void registerCoach(NewUserRequest newUserRequest);

--- a/backend/src/main/java/com/advisor/service/UserServiceImpl.java
+++ b/backend/src/main/java/com/advisor/service/UserServiceImpl.java
@@ -157,4 +157,16 @@ public class UserServiceImpl implements UserService {
         return true;
     }
 
+    @Override
+    public User registerOauth2User(String email) {
+        User lUser = new User();
+        lUser.setEmail(email);
+        lUser.setEnabled(true);
+        lUser.setActive(true);
+        Role userRole = roleRepository.findByRole(ROLE_USER);
+        lUser = repository.save(lUser);
+        lUser.setRoles(new HashSet<>(Collections.singletonList(userRole)));
+        return repository.save(lUser);
+    }
+
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.driverClassName=org.postgresql.Driver
 server.port = 8091
 spring.datasource.url =jdbc:postgresql://localhost:5432/daily_advisor
 spring.datasource.username =postgres
-spring.datasource.password =postgre
+spring.datasource.password =postgres
 spring.datasource.testWhileIdle = true
 spring.datasource.validationQuery = SELECT 1
 
@@ -57,7 +57,7 @@ google.client.clientAuthenticationScheme=form
 google.client.scope=profile email
 google.resource.userInfoUri=https://www.googleapis.com/userinfo/v2/me
 
-logging.level.root=DEBUG
+#logging.level.root=DEBUG
 
 # ===============================
 # = CUSTOM

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.driverClassName=org.postgresql.Driver
 server.port = 8091
 spring.datasource.url =jdbc:postgresql://localhost:5432/daily_advisor
 spring.datasource.username =postgres
-spring.datasource.password =postgres
+spring.datasource.password =postgre
 spring.datasource.testWhileIdle = true
 spring.datasource.validationQuery = SELECT 1
 
@@ -57,7 +57,7 @@ google.client.clientAuthenticationScheme=form
 google.client.scope=profile email
 google.resource.userInfoUri=https://www.googleapis.com/userinfo/v2/me
 
-#logging.level.root=DEBUG
+logging.level.root=DEBUG
 
 # ===============================
 # = CUSTOM

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -39,16 +39,16 @@ spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.smtp.starttls.required=true
 
-facebook.client.clientId=988907317930735
-facebook.client.clientSecret=0f8d0b1686d4bda5bd21542191c1f0d7
+facebook.client.clientId=facebookId
+facebook.client.clientSecret=secret
 facebook.client.accessTokenUri=https://graph.facebook.com/oauth/access_token
 facebook.client.userAuthorizationUri=https://www.facebook.com/dialog/oauth
 facebook.client.tokenName=oauth_token
 facebook.client.clientAuthenticationScheme=form
 facebook.resource.userInfoUri=https://graph.facebook.com/me
 
-google.client.clientId=107201344745-b9dm1qncd8nl3ls4urlsv2k6d5oi2sv3.apps.googleusercontent.com
-google.client.clientSecret=ov4zXs-0iLNsKJnTrxQbZdC6
+google.client.clientId=googleId
+google.client.clientSecret=secret
 google.client.accessTokenUri=https://www.googleapis.com/oauth2/v3/token
 google.client.userAuthorizationUri=https://accounts.google.com/o/oauth2/auth
 google.client.tokenName=oauth_token

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -13,7 +13,7 @@ spring.datasource.validationQuery = SELECT 1
 # = JPA / HIBERNATE
 # ===============================
 spring.jpa.show-sql = true
-spring.jpa.hibernate.ddl-auto = update
+spring.jpa.hibernate.ddl-auto = create
 
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
 
@@ -39,4 +39,30 @@ spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.smtp.starttls.required=true
 
+facebook.client.clientId=988907317930735
+facebook.client.clientSecret=0f8d0b1686d4bda5bd21542191c1f0d7
+facebook.client.accessTokenUri=https://graph.facebook.com/oauth/access_token
+facebook.client.userAuthorizationUri=https://www.facebook.com/dialog/oauth
+facebook.client.tokenName=oauth_token
+facebook.client.clientAuthenticationScheme=form
+facebook.resource.userInfoUri=https://graph.facebook.com/me
+
+google.client.clientId=107201344745-b9dm1qncd8nl3ls4urlsv2k6d5oi2sv3.apps.googleusercontent.com
+google.client.clientSecret=ov4zXs-0iLNsKJnTrxQbZdC6
+google.client.accessTokenUri=https://www.googleapis.com/oauth2/v3/token
+google.client.userAuthorizationUri=https://accounts.google.com/o/oauth2/auth
+google.client.tokenName=oauth_token
+google.client.authenticationScheme=query
+google.client.clientAuthenticationScheme=form
+google.client.scope=profile email
+google.resource.userInfoUri=https://www.googleapis.com/userinfo/v2/me
+
+#logging.level.root=DEBUG
+
+# ===============================
+# = CUSTOM
+# ===============================
+frontend.url.parent=http://localhost:8080
+frontend.url.main=/dashboard
+frontend.url.login=/
 frontend.server.port=8080

--- a/backend/src/test/java/com/advisor/SecurityTest.java
+++ b/backend/src/test/java/com/advisor/SecurityTest.java
@@ -1,0 +1,94 @@
+package com.advisor;
+
+import com.advisor.model.request.LoginRequest;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static io.restassured.RestAssured.given;
+
+public class SecurityTest {
+
+    private static String FRONTEND_URL = "http://localhost:8091/";
+    private static String CSRF_TOKEN_COOKIE_NAME = "XSRF-TOKEN";
+    private static String CSRF_TOKEN_HEADER_NAME = "X-XSRF-TOKEN";
+
+    private String csrf;
+    private String jwt;
+
+    @BeforeClass
+    public void setUp() {
+        this.csrf = given()
+                .when()
+                .get(FRONTEND_URL + "csrf")
+                .then()
+                .statusCode(200)
+                .and()
+                .cookie(CSRF_TOKEN_COOKIE_NAME)
+                .and()
+                .extract()
+                .cookie(CSRF_TOKEN_COOKIE_NAME);
+
+        given()
+                .when()
+                .get(FRONTEND_URL + "populate")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test(priority = 0)
+    public void loginTest() throws Exception {
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setUsername("m@m.mm");
+        loginRequest.setPassword("111111");
+
+        this.jwt = given()
+                .cookie(CSRF_TOKEN_COOKIE_NAME, csrf)
+                .header(CSRF_TOKEN_HEADER_NAME, csrf)
+                .body(loginRequest)
+                .when()
+                .post(FRONTEND_URL + "login")
+                .then()
+                .statusCode(200)
+                .and()
+                .cookie("_secu")
+                .and()
+                .extract()
+                .cookie("_secu");
+    }
+
+    @Test(priority = 1)
+    public void securedRequestTest() {
+        given()
+                .cookie(CSRF_TOKEN_COOKIE_NAME, csrf)
+                .header(CSRF_TOKEN_HEADER_NAME, csrf)
+                .cookie("_secu",jwt)
+                .when()
+                .get(FRONTEND_URL + "getUserProfile")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test(priority = 2)
+    public void logoutTest() {
+        given()
+                .cookie(CSRF_TOKEN_COOKIE_NAME, csrf)
+                .header(CSRF_TOKEN_HEADER_NAME, csrf)
+                .cookie("_secu",jwt)
+                .when()
+                .post(FRONTEND_URL + "logout")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test(priority = 3)
+    public void badJwtRequestTest() {
+        given()
+                .cookie(CSRF_TOKEN_COOKIE_NAME, csrf)
+                .header(CSRF_TOKEN_HEADER_NAME, csrf)
+                .cookie("_secu",jwt)
+                .when()
+                .get(FRONTEND_URL + "getUserProfile")
+                .then()
+                .statusCode(403);
+    }
+}


### PR DESCRIPTION
Dodałem security z jwt i csrf. Jwt zapisuje sie jako cookie http only i jest wysyłany automatycznie przez przegladarke. CSRF należy pobrać z cookie i umieścić w header każdego zapytania(jako X-XSRF-TOKEN). Jeśli nie mamy cookie z CSRF można go dostać poprzez wykonanie geta pod adres: /csrf